### PR TITLE
Feature: own state management

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "transform": {
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$",
-    "moduleFileExtensions": ["ts", "tsx"],
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "moduleFileExtensions": ["ts", "tsx", "js"],
     "coveragePathIgnorePatterns": ["/node_modules/", "/test/"],
     "coverageThreshold": {
       "global": {
@@ -74,6 +74,7 @@
     "cross-env": "^5.0.1",
     "cz-conventional-changelog": "^2.0.0",
     "husky": "^0.14.0",
+    "jasmine": "^2.8.0",
     "jest": "^21.0.0",
     "jest-cli": "^21.2.1",
     "lint-staged": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -2,20 +2,11 @@
   "name": "poa",
   "version": "0.0.0-development",
   "description": "Poa is an opinionated react framework",
-  "keywords": [
-    "react",
-    "framework",
-    "state-managment",
-    "i18n",
-    "router",
-    "opinionated"
-  ],
+  "keywords": ["react", "framework", "state-managment", "i18n", "router", "opinionated"],
   "main": "dist/poa.js",
   "module": "dist/poa.js",
   "typings": "dist/types/poa.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "author": "Ostap Chervak <ostap.chervak@gstrikersoft.com>",
   "repository": {
     "type": "git",
@@ -28,7 +19,8 @@
   "scripts": {
     "lint": "tslint -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "prebuild": "rimraf dist",
-    "build": "tsc && rollup -c rollup.config.ts && rimraf compiled && typedoc --out dist/docs --target es6 --theme minimal src",
+    "build":
+      "tsc && rollup -c rollup.config.ts && rimraf compiled && typedoc --out dist/docs --target es6 --theme minimal src",
     "start": "tsc -w & rollup -c rollup.config.ts -w",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -43,10 +35,7 @@
     "commitmsg": "validate-commit-msg"
   },
   "lint-staged": {
-    "{src,test}/**/*.ts": [
-      "prettier --write --print-width=100 --single-quote",
-      "git add"
-    ]
+    "{src,test}/**/*.ts": ["prettier --write --print-width=100 --single-quote", "git add"]
   },
   "config": {
     "commitizen": {
@@ -54,23 +43,17 @@
     },
     "validate-commit-msg": {
       "types": "conventional-commit-types",
-      "helpMessage": "Use \"npm run commit\" instead, we use conventional-changelog format :) (https://github.com/commitizen/cz-cli)"
+      "helpMessage":
+        "Use \"npm run commit\" instead, we use conventional-changelog format :) (https://github.com/commitizen/cz-cli)"
     }
   },
   "jest": {
     "transform": {
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js"
-    ],
-    "coveragePathIgnorePatterns": [
-      "/node_modules/",
-      "/test/"
-    ],
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx)$",
+    "moduleFileExtensions": ["ts", "tsx"],
+    "coveragePathIgnorePatterns": ["/node_modules/", "/test/"],
     "coverageThreshold": {
       "global": {
         "branches": 70,
@@ -128,7 +111,6 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router": "^4.2.0",
-    "react-router-dom": "^4.2.2",
-    "satcheljs": "^3.1.0"
+    "react-router-dom": "^4.2.2"
   }
 }

--- a/src/state-lib/satchel/actionCreator.ts
+++ b/src/state-lib/satchel/actionCreator.ts
@@ -1,0 +1,59 @@
+import ActionMessage from './interfaces/ActionMessage';
+import ActionCreator from './interfaces/ActionCreator';
+import { dispatch } from './dispatcher';
+import createActionId from './createActionId';
+
+export function actionCreator<
+  T extends ActionMessage = {},
+  TActionCreator extends ActionCreator<T> = () => T
+>(actionType: string, target?: TActionCreator): TActionCreator {
+  return createActionCreator(actionType, target, false);
+}
+
+export function action<
+  T extends ActionMessage = {},
+  TActionCreator extends ActionCreator<T> = () => T
+>(actionType: string, target?: TActionCreator): TActionCreator {
+  return createActionCreator(actionType, target, true);
+}
+
+function createActionCreator<T extends ActionMessage, TActionCreator extends ActionCreator<T>>(
+  actionType: string,
+  target: TActionCreator,
+  shouldDispatch: boolean
+): TActionCreator {
+  let actionId = createActionId();
+
+  let decoratedTarget = function createAction(...args: any[]) {
+    // Create the action message
+    let actionMessage: ActionMessage = target ? target.apply(null, args) : {};
+
+    // Stamp the action type
+    if (actionMessage.type) {
+      throw new Error('Action creators should not include the type property.');
+    }
+
+    // Stamp the action message with the type and the private ID
+    actionMessage.type = actionType;
+    setPrivateActionId(actionMessage, actionId);
+
+    // Dispatch if necessary
+    if (shouldDispatch) {
+      dispatch(actionMessage);
+    }
+
+    return actionMessage;
+  } as TActionCreator;
+
+  // Stamp the action creator function with the private ID
+  setPrivateActionId(decoratedTarget, actionId);
+  return decoratedTarget;
+}
+
+export function getPrivateActionId(target: any) {
+  return target.__SATCHELJS_ACTION_ID;
+}
+
+function setPrivateActionId(target: any, actionId: string) {
+  target.__SATCHELJS_ACTION_ID = actionId;
+}

--- a/src/state-lib/satchel/actionCreator.ts
+++ b/src/state-lib/satchel/actionCreator.ts
@@ -17,10 +17,22 @@ export function action<
   return createActionCreator(actionType, true, target);
 }
 
+export function asyncAction<
+  T extends ActionMessage = {},
+  TActionCreator extends ActionCreator<T> = () => T
+>(actionType: string, target?: TActionCreator): TActionCreator {
+  return createActionCreator(actionType, true, target, true);
+}
+
+async function asyncDispatch(actionMessage: ActionMessage) {
+  return await dispatch(actionMessage);
+}
+
 function createActionCreator<T extends ActionMessage, TActionCreator extends ActionCreator<T>>(
   actionType: string,
   shouldDispatch: boolean,
-  target?: TActionCreator
+  target?: TActionCreator,
+  async?: boolean
 ): TActionCreator {
   let actionId = createActionId();
 
@@ -36,6 +48,10 @@ function createActionCreator<T extends ActionMessage, TActionCreator extends Act
     // Stamp the action message with the type and the private ID
     actionMessage.type = actionType;
     setPrivateActionId(actionMessage, actionId);
+
+    if (shouldDispatch && async) {
+      return asyncDispatch(actionMessage);
+    }
 
     // Dispatch if necessary
     if (shouldDispatch) {

--- a/src/state-lib/satchel/actionCreator.ts
+++ b/src/state-lib/satchel/actionCreator.ts
@@ -7,20 +7,20 @@ export function actionCreator<
   T extends ActionMessage = {},
   TActionCreator extends ActionCreator<T> = () => T
 >(actionType: string, target?: TActionCreator): TActionCreator {
-  return createActionCreator(actionType, target, false);
+  return createActionCreator(actionType, false, target);
 }
 
 export function action<
   T extends ActionMessage = {},
   TActionCreator extends ActionCreator<T> = () => T
 >(actionType: string, target?: TActionCreator): TActionCreator {
-  return createActionCreator(actionType, target, true);
+  return createActionCreator(actionType, true, target);
 }
 
 function createActionCreator<T extends ActionMessage, TActionCreator extends ActionCreator<T>>(
   actionType: string,
-  target: TActionCreator,
-  shouldDispatch: boolean
+  shouldDispatch: boolean,
+  target?: TActionCreator
 ): TActionCreator {
   let actionId = createActionId();
 

--- a/src/state-lib/satchel/applyMiddleware.ts
+++ b/src/state-lib/satchel/applyMiddleware.ts
@@ -4,8 +4,8 @@ import { finalDispatch } from './dispatcher';
 import { getGlobalContext } from './globalContext';
 
 export default function applyMiddleware(...middleware: Middleware[]) {
-  var next: DispatchFunction = finalDispatch;
-  for (var i = middleware.length - 1; i >= 0; i--) {
+  let next: DispatchFunction = finalDispatch;
+  for (let i = middleware.length - 1; i >= 0; i--) {
     next = applyNextMiddleware(middleware[i], next);
   }
 

--- a/src/state-lib/satchel/applyMiddleware.ts
+++ b/src/state-lib/satchel/applyMiddleware.ts
@@ -1,0 +1,17 @@
+import DispatchFunction from './interfaces/DispatchFunction';
+import Middleware from './interfaces/Middleware';
+import { finalDispatch } from './dispatcher';
+import { getGlobalContext } from './globalContext';
+
+export default function applyMiddleware(...middleware: Middleware[]) {
+  var next: DispatchFunction = finalDispatch;
+  for (var i = middleware.length - 1; i >= 0; i--) {
+    next = applyNextMiddleware(middleware[i], next);
+  }
+
+  getGlobalContext().dispatchWithMiddleware = next;
+}
+
+function applyNextMiddleware(middleware: Middleware, next: DispatchFunction): DispatchFunction {
+  return actionMessage => middleware(next, actionMessage);
+}

--- a/src/state-lib/satchel/createActionId.ts
+++ b/src/state-lib/satchel/createActionId.ts
@@ -1,0 +1,5 @@
+import { getGlobalContext } from './globalContext';
+
+export default function createActionId(): string {
+  return (getGlobalContext().nextActionId++).toString();
+}

--- a/src/state-lib/satchel/createStore.ts
+++ b/src/state-lib/satchel/createStore.ts
@@ -10,5 +10,6 @@ let createStoreAction = action('createStore', function createStoreAction(
 
 export default function createStore<T>(key: string, initialState: T): () => T {
   createStoreAction(key, initialState);
+  // tslint:disable-next-line:no-angle-bracket-type-assertion
   return () => <T>getRootStore().get(key);
 }

--- a/src/state-lib/satchel/createStore.ts
+++ b/src/state-lib/satchel/createStore.ts
@@ -1,0 +1,14 @@
+import { action } from 'mobx';
+import getRootStore from './getRootStore';
+
+let createStoreAction = action('createStore', function createStoreAction(
+  key: string,
+  initialState: any
+) {
+  getRootStore().set(key, initialState);
+});
+
+export default function createStore<T>(key: string, initialState: T): () => T {
+  createStoreAction(key, initialState);
+  return () => <T>getRootStore().get(key);
+}

--- a/src/state-lib/satchel/dispatcher.ts
+++ b/src/state-lib/satchel/dispatcher.ts
@@ -36,7 +36,7 @@ export function finalDispatch(actionMessage: ActionMessage): void | Promise<void
     });
 
     if (promises.length) {
-      return promises.length == 1 ? promises[0] : Promise.all(promises);
+      return promises.length === 1 ? promises[0] : Promise.all(promises);
     }
   }
 }

--- a/src/state-lib/satchel/dispatcher.ts
+++ b/src/state-lib/satchel/dispatcher.ts
@@ -1,0 +1,42 @@
+import ActionMessage from './interfaces/ActionMessage';
+import Subscriber from './interfaces/Subscriber';
+import { getPrivateActionId } from './actionCreator';
+import { getGlobalContext } from './globalContext';
+
+export function subscribe(actionId: string, callback: Subscriber<any>) {
+  let subscriptions = getGlobalContext().subscriptions;
+  if (!subscriptions[actionId]) {
+    subscriptions[actionId] = [];
+  }
+
+  subscriptions[actionId].push(callback);
+}
+
+export function dispatch(actionMessage: ActionMessage) {
+  if (getGlobalContext().inMutator) {
+    throw new Error('Mutators cannot dispatch further actions.');
+  }
+
+  let dispatchWithMiddleware = getGlobalContext().dispatchWithMiddleware || finalDispatch;
+  dispatchWithMiddleware(actionMessage);
+}
+
+export function finalDispatch(actionMessage: ActionMessage): void | Promise<void> {
+  let actionId = getPrivateActionId(actionMessage);
+  let subscribers = getGlobalContext().subscriptions[actionId];
+
+  if (subscribers) {
+    let promises: Promise<any>[] = [];
+
+    subscribers.forEach(subscriber => {
+      let returnValue = subscriber(actionMessage);
+      if (returnValue) {
+        promises.push(returnValue);
+      }
+    });
+
+    if (promises.length) {
+      return promises.length == 1 ? promises[0] : Promise.all(promises);
+    }
+  }
+}

--- a/src/state-lib/satchel/dispatcher.ts
+++ b/src/state-lib/satchel/dispatcher.ts
@@ -18,7 +18,7 @@ export function dispatch(actionMessage: ActionMessage) {
   }
 
   let dispatchWithMiddleware = getGlobalContext().dispatchWithMiddleware || finalDispatch;
-  dispatchWithMiddleware(actionMessage);
+  return dispatchWithMiddleware(actionMessage);
 }
 
 export function finalDispatch(actionMessage: ActionMessage): void | Promise<void> {

--- a/src/state-lib/satchel/getRootStore.ts
+++ b/src/state-lib/satchel/getRootStore.ts
@@ -1,0 +1,11 @@
+/* tslint:disable:no-unused-imports */
+import { ObservableMap } from 'mobx';
+/* tslint:enable:no-unused-imports */
+import { getGlobalContext } from './globalContext';
+
+/**
+ * Satchel-provided root store getter
+ */
+export default function getRootStore() {
+  return getGlobalContext().rootStore;
+}

--- a/src/state-lib/satchel/globalContext.ts
+++ b/src/state-lib/satchel/globalContext.ts
@@ -2,8 +2,6 @@ import { map, ObservableMap } from 'mobx';
 import ActionMessage from './interfaces/ActionMessage';
 import DispatchFunction from './interfaces/DispatchFunction';
 import Subscriber from './interfaces/Subscriber';
-import ActionContext from './legacy/ActionContext';
-import ActionFunction from './legacy/ActionFunction';
 
 const schemaVersion = 3;
 
@@ -13,51 +11,38 @@ export interface GlobalContext {
   rootStore: ObservableMap<any>;
   nextActionId: number;
   subscriptions: { [key: string]: Subscriber<ActionMessage>[] };
-  dispatchWithMiddleware: DispatchFunction;
+  dispatchWithMiddleware: DispatchFunction | null;
   inMutator: boolean;
-
-  // Legacy properties
-  legacyInDispatch: number;
-  legacyDispatchWithMiddleware: (
-    action: ActionFunction,
-    actionType: string,
-    args: IArguments,
-    actionContext: ActionContext
-  ) => Promise<any> | void;
-  legacyTestMode: boolean;
 }
 
 declare var global: {
-  __satchelGlobalContext: GlobalContext;
+  __poaSatchelGlobalContext: GlobalContext;
 };
 
 // A reset global context function to be used INTERNALLY by SatchelJS tests and for initialization ONLY
 export function __resetGlobalContext() {
-  global.__satchelGlobalContext = {
+  global.__poaSatchelGlobalContext = {
     schemaVersion: schemaVersion,
     rootStore: map({}),
     nextActionId: 0,
     subscriptions: {},
     dispatchWithMiddleware: null,
-    inMutator: false,
-    legacyInDispatch: 0,
-    legacyDispatchWithMiddleware: null,
-    legacyTestMode: false
+    inMutator: false
   };
 }
 
 export function ensureGlobalContextSchemaVersion() {
-  if (schemaVersion != global.__satchelGlobalContext.schemaVersion) {
+  if (schemaVersion !== global.__poaSatchelGlobalContext.schemaVersion) {
     throw new Error('Detected incompatible SatchelJS versions loaded.');
   }
 }
 
 export function getGlobalContext() {
-  return global.__satchelGlobalContext;
+  return global.__poaSatchelGlobalContext;
 }
 
 // Side Effects: actually initialize the global context if it is undefined
-if (!global.__satchelGlobalContext) {
+if (!global.__poaSatchelGlobalContext) {
   __resetGlobalContext();
 } else {
   ensureGlobalContextSchemaVersion();

--- a/src/state-lib/satchel/globalContext.ts
+++ b/src/state-lib/satchel/globalContext.ts
@@ -1,0 +1,64 @@
+import { map, ObservableMap } from 'mobx';
+import ActionMessage from './interfaces/ActionMessage';
+import DispatchFunction from './interfaces/DispatchFunction';
+import Subscriber from './interfaces/Subscriber';
+import ActionContext from './legacy/ActionContext';
+import ActionFunction from './legacy/ActionFunction';
+
+const schemaVersion = 3;
+
+// Interfaces for Global Context
+export interface GlobalContext {
+  schemaVersion: number;
+  rootStore: ObservableMap<any>;
+  nextActionId: number;
+  subscriptions: { [key: string]: Subscriber<ActionMessage>[] };
+  dispatchWithMiddleware: DispatchFunction;
+  inMutator: boolean;
+
+  // Legacy properties
+  legacyInDispatch: number;
+  legacyDispatchWithMiddleware: (
+    action: ActionFunction,
+    actionType: string,
+    args: IArguments,
+    actionContext: ActionContext
+  ) => Promise<any> | void;
+  legacyTestMode: boolean;
+}
+
+declare var global: {
+  __satchelGlobalContext: GlobalContext;
+};
+
+// A reset global context function to be used INTERNALLY by SatchelJS tests and for initialization ONLY
+export function __resetGlobalContext() {
+  global.__satchelGlobalContext = {
+    schemaVersion: schemaVersion,
+    rootStore: map({}),
+    nextActionId: 0,
+    subscriptions: {},
+    dispatchWithMiddleware: null,
+    inMutator: false,
+    legacyInDispatch: 0,
+    legacyDispatchWithMiddleware: null,
+    legacyTestMode: false
+  };
+}
+
+export function ensureGlobalContextSchemaVersion() {
+  if (schemaVersion != global.__satchelGlobalContext.schemaVersion) {
+    throw new Error('Detected incompatible SatchelJS versions loaded.');
+  }
+}
+
+export function getGlobalContext() {
+  return global.__satchelGlobalContext;
+}
+
+// Side Effects: actually initialize the global context if it is undefined
+if (!global.__satchelGlobalContext) {
+  __resetGlobalContext();
+} else {
+  ensureGlobalContextSchemaVersion();
+}

--- a/src/state-lib/satchel/index.ts
+++ b/src/state-lib/satchel/index.ts
@@ -1,0 +1,21 @@
+import { useStrict } from 'mobx';
+
+// Current API
+export { default as ActionCreator } from './interfaces/ActionCreator';
+export { default as ActionMessage } from './interfaces/ActionMessage';
+export { default as DispatchFunction } from './interfaces/DispatchFunction';
+export { default as Middleware } from './interfaces/Middleware';
+export { default as MutatorFunction } from './interfaces/MutatorFunction';
+export { default as OrchestratorFunction } from './interfaces/OrchestratorFunction';
+export { action, actionCreator } from './actionCreator';
+export { default as applyMiddleware } from './applyMiddleware';
+export { default as createStore } from './createStore';
+export { dispatch } from './dispatcher';
+export { default as mutator } from './mutator';
+export { default as orchestrator } from './orchestrator';
+export { default as getRootStore } from './getRootStore';
+export { mutatorAction, orchestratorAction } from './simpleSubscribers';
+export { useStrict };
+
+// Default to MobX strict mode
+useStrict(true);

--- a/src/state-lib/satchel/interfaces/ActionCreator.ts
+++ b/src/state-lib/satchel/interfaces/ActionCreator.ts
@@ -1,0 +1,4 @@
+import ActionMessage from './ActionMessage';
+
+type ActionCreator<T extends ActionMessage> = (...args: any[]) => T;
+export default ActionCreator;

--- a/src/state-lib/satchel/interfaces/ActionMessage.ts
+++ b/src/state-lib/satchel/interfaces/ActionMessage.ts
@@ -1,0 +1,6 @@
+interface ActionMessage {
+  type?: string;
+  [key: string]: any;
+}
+
+export default ActionMessage;

--- a/src/state-lib/satchel/interfaces/DispatchFunction.ts
+++ b/src/state-lib/satchel/interfaces/DispatchFunction.ts
@@ -1,0 +1,4 @@
+import ActionMessage from './ActionMessage';
+
+type DispatchFunction = (actionMessage: ActionMessage) => void | Promise<void>;
+export default DispatchFunction;

--- a/src/state-lib/satchel/interfaces/Middleware.ts
+++ b/src/state-lib/satchel/interfaces/Middleware.ts
@@ -1,0 +1,5 @@
+import ActionMessage from './ActionMessage';
+import DispatchFunction from './DispatchFunction';
+
+type Middleware = (next: DispatchFunction, actionMessage: ActionMessage) => void;
+export default Middleware;

--- a/src/state-lib/satchel/interfaces/MutatorFunction.ts
+++ b/src/state-lib/satchel/interfaces/MutatorFunction.ts
@@ -1,0 +1,4 @@
+import ActionMessage from './ActionMessage';
+
+type MutatorFunction<T extends ActionMessage> = (actionMessage: T) => void;
+export default MutatorFunction;

--- a/src/state-lib/satchel/interfaces/OrchestratorFunction.ts
+++ b/src/state-lib/satchel/interfaces/OrchestratorFunction.ts
@@ -1,0 +1,4 @@
+import ActionMessage from './ActionMessage';
+
+type OrchestratorFunction<T extends ActionMessage> = (actionMessage: T) => void | Promise<any>;
+export default OrchestratorFunction;

--- a/src/state-lib/satchel/interfaces/SimpleAction.ts
+++ b/src/state-lib/satchel/interfaces/SimpleAction.ts
@@ -1,0 +1,5 @@
+interface SimpleAction {
+  (...args: any[]): void;
+}
+
+export default SimpleAction;

--- a/src/state-lib/satchel/interfaces/Subscriber.ts
+++ b/src/state-lib/satchel/interfaces/Subscriber.ts
@@ -1,0 +1,6 @@
+import ActionMessage from './ActionMessage';
+import MutatorFunction from './MutatorFunction';
+import OrchestratorFunction from './OrchestratorFunction';
+
+type Subscriber<T extends ActionMessage> = MutatorFunction<T> | OrchestratorFunction<T>;
+export default Subscriber;

--- a/src/state-lib/satchel/mutator.ts
+++ b/src/state-lib/satchel/mutator.ts
@@ -1,0 +1,35 @@
+import { action } from 'mobx';
+
+import ActionCreator from './interfaces/ActionCreator';
+import ActionMessage from './interfaces/ActionMessage';
+import MutatorFunction from './interfaces/MutatorFunction';
+import { getPrivateActionId } from './actionCreator';
+import { subscribe } from './dispatcher';
+import { getGlobalContext } from './globalContext';
+
+export default function mutator<T extends ActionMessage>(
+  actionCreator: ActionCreator<T>,
+  target: MutatorFunction<T>
+): MutatorFunction<T> {
+  let actionId = getPrivateActionId(actionCreator);
+  if (!actionId) {
+    throw new Error('Mutators can only subscribe to action creators.');
+  }
+
+  // Wrap the callback in a MobX action so it can modify the store
+  let wrappedTarget = action(target);
+
+  // Subscribe to the action
+  subscribe(actionId, (actionMessage: T) => {
+    try {
+      getGlobalContext().inMutator = true;
+      if (wrappedTarget(actionMessage)) {
+        throw new Error('Mutators cannot return a value and cannot be async.');
+      }
+    } finally {
+      getGlobalContext().inMutator = false;
+    }
+  });
+
+  return target;
+}

--- a/src/state-lib/satchel/orchestrator.ts
+++ b/src/state-lib/satchel/orchestrator.ts
@@ -1,0 +1,18 @@
+import ActionCreator from './interfaces/ActionCreator';
+import ActionMessage from './interfaces/ActionMessage';
+import OrchestratorFunction from './interfaces/OrchestratorFunction';
+import { getPrivateActionId } from './actionCreator';
+import { subscribe } from './dispatcher';
+
+export default function orchestrator<T extends ActionMessage>(
+  actionCreator: ActionCreator<T>,
+  target: OrchestratorFunction<T>
+) {
+  let actionId = getPrivateActionId(actionCreator);
+  if (!actionId) {
+    throw new Error('Orchestrators can only subscribe to action creators.');
+  }
+
+  subscribe(actionId, target);
+  return target;
+}

--- a/src/state-lib/satchel/simpleSubscribers.ts
+++ b/src/state-lib/satchel/simpleSubscribers.ts
@@ -1,0 +1,28 @@
+import ActionCreator from './interfaces/ActionCreator';
+import SimpleAction from './interfaces/SimpleAction';
+import Subscriber from './interfaces/Subscriber';
+import { action } from './actionCreator';
+import mutator from './mutator';
+import orchestrator from './orchestrator';
+
+export function createSimpleSubscriber(decorator: Function) {
+  return function simpleSubscriber<T extends SimpleAction>(actionType: string, target: T): T {
+    // Create the action creator
+    let simpleActionCreator = action(actionType, function simpleActionCreator() {
+      return {
+        args: arguments
+      };
+    });
+
+    // Create the subscriber
+    decorator(simpleActionCreator, function simpleSubscriberCallback(actionMessage: any) {
+      target.apply(null, actionMessage.args);
+    });
+
+    // Return a function that dispatches that action
+    return (simpleActionCreator as any) as T;
+  };
+}
+
+export const mutatorAction = createSimpleSubscriber(mutator);
+export const orchestratorAction = createSimpleSubscriber(orchestrator);

--- a/src/state-lib/state.ts
+++ b/src/state-lib/state.ts
@@ -10,7 +10,7 @@ import {
   ActionCreator,
   OrchestratorFunction,
   ActionMessage
-} from 'satcheljs';
+} from './satchel';
 import { History } from 'history';
 import { injectPropertyToAllComponents } from '../components-registry';
 import { logger } from '../logger-lib/logger';

--- a/test/satchel/actionCreator.test.ts
+++ b/test/satchel/actionCreator.test.ts
@@ -1,10 +1,12 @@
 import {
   action,
+  asyncAction,
   actionCreator,
   getPrivateActionId
 } from '../../src/state-lib/satchel/actionCreator';
 import * as createActionId from '../../src/state-lib/satchel/createActionId';
 import * as dispatcher from '../../src/state-lib/satchel/dispatcher';
+import orchestrator from '../../src/state-lib/satchel/orchestrator';
 
 describe('actionCreator', () => {
   it('returns the created action message', () => {
@@ -95,5 +97,43 @@ describe('action', () => {
 
     // Assert
     expect(dispatcher.dispatch).toHaveBeenCalledWith(actionMessage);
+  });
+
+  it('dispatches async action', async () => {
+    // Arrange
+    let actionMessage = {};
+    const testAction = asyncAction('testAction', () => actionMessage);
+    const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+    let data: number;
+
+    orchestrator(testAction, async payload => {
+      await sleep(1);
+      expect(payload).toBe(actionMessage);
+      data = 1;
+    });
+
+    // Act
+    await testAction();
+
+    // Assert
+    expect(data).toEqual(1);
+  });
+
+  it('return error on orchestrator', async done => {
+    // Arrange
+    let actionMessage = {};
+    const testAction = asyncAction('testAction', () => actionMessage);
+
+    orchestrator(testAction, async payload => {
+      throw new Error('');
+    });
+
+    // Act
+    try {
+      await testAction();
+      fail('it should throw an error');
+    } catch (e) {
+      done();
+    }
   });
 });

--- a/test/satchel/actionCreator.test.ts
+++ b/test/satchel/actionCreator.test.ts
@@ -1,0 +1,99 @@
+import {
+  action,
+  actionCreator,
+  getPrivateActionId
+} from '../../src/state-lib/satchel/actionCreator';
+import * as createActionId from '../../src/state-lib/satchel/createActionId';
+import * as dispatcher from '../../src/state-lib/satchel/dispatcher';
+
+describe('actionCreator', () => {
+  it('returns the created action message', () => {
+    // Arrange
+    const testAction = actionCreator('testAction', (arg0, arg1) => {
+      return {
+        arg0,
+        arg1
+      };
+    });
+
+    // Act
+    let actionMessage = testAction('value0', 'value1');
+
+    // Assert
+    expect(actionMessage.arg0).toBe('value0');
+    expect(actionMessage.arg1).toBe('value1');
+  });
+
+  it('returns a default action message if no factory is provided', () => {
+    // Arrange
+    const testAction = actionCreator('testAction');
+
+    // Act
+    let actionMessage = testAction();
+
+    // Assert
+    expect(actionMessage).not.toBeNull();
+  });
+
+  it('stamps the action message with the type and private action ID', () => {
+    // Arrange
+    spyOn(createActionId, 'default').and.returnValue('id0');
+    let actionType = 'testAction';
+    const testAction = actionCreator(actionType);
+
+    // Act
+    let actionMessage = testAction();
+
+    // Assert
+    expect((actionMessage as any).type).toBe(actionType);
+    expect(getPrivateActionId(actionMessage)).toBe('id0');
+  });
+
+  it('does not dispatch the action message', () => {
+    // Arrange
+    const testAction = actionCreator('testAction');
+    spyOn(dispatcher, 'dispatch');
+
+    // Act
+    testAction();
+
+    // Assert
+    expect(dispatcher.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('throws if the action message already has a type', () => {
+    // Arrange
+    const testAction = actionCreator('testAction', () => {
+      return { type: 'testAction' };
+    });
+
+    // Act / Assert
+    expect(testAction).toThrow();
+  });
+
+  it('gets stamped with the private action ID', () => {
+    // Arrange
+    spyOn(createActionId, 'default').and.returnValue('id1');
+
+    // Act
+    const testAction = actionCreator('testAction');
+
+    // Assert
+    expect(getPrivateActionId(testAction)).toBe('id1');
+  });
+});
+
+describe('action', () => {
+  it('dispatches the action message', () => {
+    // Arrange
+    let actionMessage = {};
+    const testAction = action('testAction', () => actionMessage);
+    spyOn(dispatcher, 'dispatch');
+
+    // Act
+    testAction();
+
+    // Assert
+    expect(dispatcher.dispatch).toHaveBeenCalledWith(actionMessage);
+  });
+});

--- a/test/satchel/applyMiddleware.test.ts
+++ b/test/satchel/applyMiddleware.test.ts
@@ -1,0 +1,66 @@
+import applyMiddleware from '../../src/state-lib/satchel/applyMiddleware';
+import * as dispatcher from '../../src/state-lib/satchel/dispatcher';
+import { getGlobalContext, __resetGlobalContext } from '../../src/state-lib/satchel/globalContext';
+
+describe('applyMiddleware', () => {
+  it('updates dispatchWithMiddleware to point to the middleware pipeline', () => {
+    // Arrange
+    __resetGlobalContext();
+    let testMiddleware = jasmine.createSpy('testMiddleware');
+
+    // Act
+    applyMiddleware(testMiddleware);
+    getGlobalContext().dispatchWithMiddleware({});
+
+    // Assert
+    expect(testMiddleware).toHaveBeenCalled();
+  });
+
+  it('the action message and next delegate get passed to middleware', () => {
+    // Arrange
+    __resetGlobalContext();
+
+    let dispatchedActionMessage = {};
+    let actualNext;
+    let actualActionMessage;
+
+    applyMiddleware((next: any, actionMessage: any) => {
+      actualNext = next;
+      actualActionMessage = actionMessage;
+    });
+
+    // Act
+    getGlobalContext().dispatchWithMiddleware(dispatchedActionMessage);
+
+    // Assert
+    expect(actualActionMessage).toBe(dispatchedActionMessage);
+    expect(actualNext).toBe(dispatcher.finalDispatch);
+  });
+
+  it('middleware and finalDispatch get called in order', () => {
+    // Arrange
+    __resetGlobalContext();
+    let sequence: string[] = [];
+
+    spyOn(dispatcher, 'finalDispatch').and.callFake(() => {
+      sequence.push('finalDispatch');
+    });
+
+    applyMiddleware(
+      (next: any, actionMessage: any) => {
+        sequence.push('middleware1');
+        next(actionMessage);
+      },
+      (next: any, actionMessage: any) => {
+        sequence.push('middleware2');
+        next(actionMessage);
+      }
+    );
+
+    // Act
+    getGlobalContext().dispatchWithMiddleware({});
+
+    // Assert
+    expect(sequence).toEqual(['middleware1', 'middleware2', 'finalDispatch']);
+  });
+});

--- a/test/satchel/createActionId.test.ts
+++ b/test/satchel/createActionId.test.ts
@@ -1,0 +1,14 @@
+import createActionId from '../../src/state-lib/satchel/createActionId';
+import { __resetGlobalContext } from '../../src/state-lib/satchel/globalContext';
+
+describe('createActionId', () => {
+  it('returns the next incremental ID for each call', () => {
+    // Arrange
+    __resetGlobalContext();
+
+    // Act / Assert
+    expect(createActionId()).toBe('0');
+    expect(createActionId()).toBe('1');
+    expect(createActionId()).toBe('2');
+  });
+});

--- a/test/satchel/createStoreTests.test.ts
+++ b/test/satchel/createStoreTests.test.ts
@@ -1,0 +1,18 @@
+import getRootStore from '../../src/state-lib/satchel/getRootStore';
+import createStore from '../../src/state-lib/satchel/createStore';
+import { __resetGlobalContext } from '../../src/state-lib/satchel/globalContext';
+
+describe('createStore', () => {
+  it('creates a subtree under rootStore', () => {
+    // Arrange
+    __resetGlobalContext();
+    let initialState = { testProp: 'testValue' };
+
+    // Act
+    let store = createStore('testStore', initialState)();
+
+    // Assert
+    expect(store).toBe(initialState);
+    expect(getRootStore().get('testStore')).toBe(initialState);
+  });
+});

--- a/test/satchel/dispatcherTests.test.ts
+++ b/test/satchel/dispatcherTests.test.ts
@@ -1,0 +1,148 @@
+import * as actionCreator from '../../src/state-lib/satchel/actionCreator';
+import * as dispatcher from '../../src/state-lib/satchel/dispatcher';
+import * as globalContext from '../../src/state-lib/satchel/globalContext';
+
+describe('dispatcher', () => {
+  let mockGlobalContext: any;
+
+  beforeEach(() => {
+    mockGlobalContext = {
+      subscriptions: {},
+      dispatchWithMiddleware: jasmine.createSpy('dispatchWithMiddleware'),
+      inMutator: false
+    };
+
+    spyOn(globalContext, 'getGlobalContext').and.returnValue(mockGlobalContext);
+  });
+
+  it('subscribe registers a callback for a given action', () => {
+    // Arrange
+    let actionId = 'testActionId';
+    let callback = () => ({});
+
+    // Act
+    dispatcher.subscribe(actionId, callback);
+
+    // Assert
+    expect(mockGlobalContext.subscriptions[actionId]).toBeDefined();
+    expect(mockGlobalContext.subscriptions[actionId].length).toBe(1);
+    expect(mockGlobalContext.subscriptions[actionId][0]).toBe(callback);
+  });
+
+  it('subscribe can register multiple callbacks', () => {
+    // Arrange
+    let actionId = 'testActionId';
+    let callback0 = () => ({});
+    let callback1 = () => ({});
+
+    // Act
+    dispatcher.subscribe(actionId, callback0);
+    dispatcher.subscribe(actionId, callback1);
+
+    // Assert
+    expect(mockGlobalContext.subscriptions[actionId]).toEqual([callback0, callback1]);
+  });
+
+  it('dispatch calls dispatchWithMiddleware', () => {
+    // Arrange
+    let actionMessage = {};
+
+    // Act
+    dispatcher.dispatch(actionMessage);
+
+    // Assert
+    expect(mockGlobalContext.dispatchWithMiddleware).toHaveBeenCalledWith(actionMessage);
+  });
+
+  it('dispatch calls finalDispatch if dispatchWithMiddleware is null', () => {
+    // Arrange
+    mockGlobalContext.dispatchWithMiddleware = null;
+    let actionId = 'testActionId';
+    spyOn(actionCreator, 'getPrivateActionId').and.returnValue(actionId);
+
+    let callback = jasmine.createSpy('callback0');
+    mockGlobalContext.subscriptions[actionId] = [callback];
+
+    // Act
+    dispatcher.dispatch({});
+
+    // Assert
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('dispatch throws if called within a mutator', () => {
+    // Arrange
+    mockGlobalContext.inMutator = true;
+
+    // Act / Assert
+    expect(() => {
+      dispatcher.dispatch({});
+    }).toThrow();
+  });
+
+  it('finalDispatch calls all subscribers for a given action', () => {
+    // Arrange
+    let actionMessage = {};
+    let actionId = 'testActionId';
+    spyOn(actionCreator, 'getPrivateActionId').and.returnValue(actionId);
+
+    let callback0 = jasmine.createSpy('callback0');
+    let callback1 = jasmine.createSpy('callback1');
+    mockGlobalContext.subscriptions[actionId] = [callback0, callback1];
+
+    // Act
+    dispatcher.finalDispatch(actionMessage);
+
+    // Assert
+    expect(callback0).toHaveBeenCalledWith(actionMessage);
+    expect(callback1).toHaveBeenCalledWith(actionMessage);
+  });
+
+  it('finalDispatch handles the case where there are no subscribers', () => {
+    // Arrange
+    spyOn(actionCreator, 'getPrivateActionId').and.returnValue('testActionId');
+
+    // Act / Assert
+    expect(() => {
+      dispatcher.finalDispatch({});
+    }).not.toThrow();
+  });
+
+  it('if one subscriber returns a Promise, finalDispatch returns it', () => {
+    // Arrange
+    let actionId = 'testActionId';
+    spyOn(actionCreator, 'getPrivateActionId').and.returnValue(actionId);
+
+    let promise = Promise.resolve();
+    let callback = () => promise;
+    mockGlobalContext.subscriptions[actionId] = [callback];
+
+    // Act
+    let returnValue = dispatcher.finalDispatch({});
+
+    // Assert
+    expect(returnValue).toBe(promise);
+  });
+
+  it('if multiple subscribers returns Promises, finalDispatch returns an aggregate Promise', () => {
+    // Arrange
+    let actionId = 'testActionId';
+    spyOn(actionCreator, 'getPrivateActionId').and.returnValue(actionId);
+
+    let promise1 = Promise.resolve();
+    let callback1 = () => promise1;
+    let promise2 = Promise.resolve();
+    let callback2 = () => promise2;
+    mockGlobalContext.subscriptions[actionId] = [callback1, callback2];
+
+    let aggregatePromise = Promise.resolve();
+    spyOn(Promise, 'all').and.returnValue(aggregatePromise);
+
+    // Act
+    let returnValue = dispatcher.finalDispatch({});
+
+    // Assert
+    expect(Promise.all).toHaveBeenCalledWith([promise1, promise2]);
+    expect(returnValue).toBe(aggregatePromise);
+  });
+});

--- a/test/satchel/endToEndTests.test.ts
+++ b/test/satchel/endToEndTests.test.ts
@@ -1,0 +1,104 @@
+import { action } from '../../src/state-lib/satchel/actionCreator';
+import applyMiddleware from '../../src/state-lib/satchel/applyMiddleware';
+import { dispatch } from '../../src/state-lib/satchel/dispatcher';
+import mutator from '../../src/state-lib/satchel/mutator';
+import orchestrator from '../../src/state-lib/satchel/orchestrator';
+import { mutatorAction } from '../../src/state-lib/satchel/simpleSubscribers';
+import createStore from '../../src/state-lib/satchel/createStore';
+
+describe('satcheljs', () => {
+  it('mutators subscribe to actions', () => {
+    let actualValue;
+
+    // Create an action creator
+    let testAction = action('testAction', function testAction(value: string) {
+      return {
+        value: value
+      };
+    });
+
+    // Create a mutator that subscribes to it
+    let onTestAction = mutator(testAction, function(actionMessage) {
+      actualValue = actionMessage.value;
+    });
+
+    // Dispatch the action
+    testAction('test');
+
+    // Validate that the mutator was called with the dispatched action
+    expect(actualValue).toBe('test');
+  });
+
+  it('mutatorAction dispatches an action and subscribes to it', () => {
+    // Arrange
+    let arg1Value;
+    let arg2Value;
+
+    let testMutatorAction = mutatorAction('testMutatorAction', function testMutatorAction(
+      arg1: string,
+      arg2: number
+    ) {
+      arg1Value = arg1;
+      arg2Value = arg2;
+    });
+
+    // Act
+    testMutatorAction('testValue', 2);
+
+    // Assert
+    expect(arg1Value).toBe('testValue');
+    expect(arg2Value).toBe(2);
+  });
+
+  it('mutators can modify the store', () => {
+    // Arrange
+    let store = createStore('testStore', { testProperty: 'testValue' })();
+    let modifyStore = action('modifyStore');
+
+    let onModifyStore = mutator(modifyStore, actionMessage => {
+      store.testProperty = 'newValue';
+    });
+
+    // Act
+    modifyStore();
+
+    // Assert
+    expect(store.testProperty).toBe('newValue');
+  });
+
+  it('middleware gets called during dispatch', () => {
+    // Arrange
+    let actualValue;
+    let expectedValue = { type: 'testMiddleware' };
+
+    applyMiddleware((next, actionMessage) => {
+      actualValue = actionMessage;
+      next(actionMessage);
+    });
+
+    // Act
+    dispatch(expectedValue);
+
+    // Assert
+    expect(actualValue).toBe(expectedValue);
+  });
+
+  it('middleware can handle promises returned from orchestrators', async () => {
+    // Arrange
+    let testAction = action('testAction');
+    orchestrator(testAction, () => Promise.resolve(1));
+    orchestrator(testAction, () => Promise.resolve(2));
+
+    let returnedPromise;
+    applyMiddleware((next, actionMessage) => {
+      returnedPromise = next(actionMessage);
+    });
+
+    // Act
+    testAction();
+    let promiseValues = await returnedPromise;
+
+    // Assert
+    expect(promiseValues).toEqual([1, 2]);
+  });
+});

--- a/test/satchel/globalContextTests.test.ts
+++ b/test/satchel/globalContextTests.test.ts
@@ -1,0 +1,28 @@
+import { isObservableMap } from 'mobx';
+import {
+  __resetGlobalContext,
+  getGlobalContext,
+  ensureGlobalContextSchemaVersion
+} from '../../src/state-lib/satchel/globalContext';
+
+describe('globalContext', () => {
+  beforeEach(() => {
+    __resetGlobalContext();
+  });
+
+  it('will throw error if the wrong schema version is detected', () => {
+    // Arrange
+    getGlobalContext().schemaVersion = -999;
+
+    // Act / Assert
+    expect(ensureGlobalContextSchemaVersion).toThrow();
+  });
+
+  it('rootStore is an ObservableMap', () => {
+    // Act
+    let rootStore = getGlobalContext().rootStore;
+
+    // Assert
+    expect(isObservableMap(rootStore)).toBeTruthy();
+  });
+});

--- a/test/satchel/mutatorTests.test.ts
+++ b/test/satchel/mutatorTests.test.ts
@@ -1,0 +1,99 @@
+import mutator from '../../src/state-lib/satchel/mutator';
+import * as dispatcher from '../../src/state-lib/satchel/dispatcher';
+import * as globalContext from '../../src/state-lib/satchel/globalContext';
+
+jest.genMockFromModule('mobx');
+
+const mobx = require('mobx');
+
+describe('mutator', () => {
+  let mockGlobalContext: any;
+
+  beforeEach(() => {
+    mockGlobalContext = { inMutator: false };
+    spyOn(globalContext, 'getGlobalContext').and.returnValue(mockGlobalContext);
+    spyOn(dispatcher, 'subscribe');
+  });
+
+  it('throws if the action creator does not have an action ID', () => {
+    // Arrange
+    let actionCreator: any = {};
+
+    // Act / Assert
+    expect(() => {
+      mutator(actionCreator, () => ({}));
+    }).toThrow();
+  });
+
+  it('subscribes the target function to the action', () => {
+    // Arrange
+    let actionId = 'testAction';
+    let actionCreator: any = { __SATCHELJS_ACTION_ID: actionId };
+
+    // Act
+    mutator(actionCreator, () => ({}));
+
+    // Assert
+    expect(dispatcher.subscribe).toHaveBeenCalled();
+    expect((dispatcher.subscribe as any).calls.argsFor(0)[0]).toBe(actionId);
+  });
+
+  it('wraps the subscribed callback in a MobX action', () => {
+    // Arrange
+    let callback = () => {
+      //
+    };
+    let wrappedCallback = () => {
+      //
+    };
+    let actionCreator: any = { __SATCHELJS_ACTION_ID: 'testAction' };
+    jest.spyOn(mobx, 'action').mockReturnValueOnce(wrappedCallback);
+
+    // Act
+    mutator(actionCreator, callback);
+
+    // Assert
+    expect(mobx.action).toHaveBeenCalledWith(callback);
+  });
+
+  it('returns the target function', () => {
+    // Arrange
+    let actionCreator: any = { __SATCHELJS_ACTION_ID: 'testAction' };
+    let callback = () => ({});
+
+    // Act
+    let returnValue = mutator(actionCreator, callback);
+
+    // Assert
+    expect(returnValue).toBe(callback);
+  });
+
+  it('throws if the target function is async', () => {
+    // Arrange
+    let actionCreator: any = { __SATCHELJS_ACTION_ID: 'testAction' };
+    let callback = async () => ({});
+
+    mutator(actionCreator, callback);
+    let subscribedCallback = (dispatcher.subscribe as jasmine.Spy).calls.argsFor(0)[1];
+
+    // Act / Assert
+    expect(subscribedCallback).toThrow();
+  });
+
+  it('sets the inMutator flag to true for the duration of the mutator callback', () => {
+    // Arrange
+    let actionCreator: any = { __SATCHELJS_ACTION_ID: 'testAction' };
+    let inMutatorValue;
+    let callback = () => {
+      expect(mockGlobalContext.inMutator).toBeTruthy();
+    };
+    mutator(actionCreator, callback);
+
+    // Act
+    let subscribedCallback = (dispatcher.subscribe as jasmine.Spy).calls.argsFor(0)[1];
+    subscribedCallback();
+
+    // Assert
+    expect(mockGlobalContext.inMutator).toBeFalsy();
+  });
+});

--- a/test/satchel/orchestratorTests.test.ts
+++ b/test/satchel/orchestratorTests.test.ts
@@ -1,0 +1,46 @@
+import orchestrator from '../../src/state-lib/satchel/orchestrator';
+import * as dispatcher from '../../src/state-lib/satchel/dispatcher';
+
+describe('orchestrator', () => {
+  it('throws if the action creator does not have an action ID', () => {
+    // Arrange
+    let actionCreator: any = {};
+
+    // Act / Assert
+    expect(() => {
+      orchestrator(actionCreator, () => {
+        //
+      });
+    }).toThrow();
+  });
+
+  it('subscribes the target function to the action', () => {
+    // Arrange
+    let callback = () => {
+      //
+    };
+    let actionId = 'testAction';
+    let actionCreator: any = { __SATCHELJS_ACTION_ID: actionId };
+    spyOn(dispatcher, 'subscribe');
+
+    // Act
+    orchestrator(actionCreator, callback);
+
+    // Assert
+    expect(dispatcher.subscribe).toHaveBeenCalledWith(actionId, callback);
+  });
+
+  it('returns the target function', () => {
+    // Arrange
+    let actionCreator: any = { __SATCHELJS_ACTION_ID: 'testAction' };
+    let callback = () => {
+      //
+    };
+
+    // Act
+    let returnValue = orchestrator(actionCreator, callback);
+
+    // Assert
+    expect(returnValue).toBe(callback);
+  });
+});

--- a/test/satchel/simpleSubscribersTests.test.ts
+++ b/test/satchel/simpleSubscribersTests.test.ts
@@ -1,0 +1,61 @@
+import { createSimpleSubscriber } from '../../src/state-lib/satchel/simpleSubscribers';
+import { __resetGlobalContext } from '../../src/state-lib/satchel/globalContext';
+import * as actionCreator from '../../src/state-lib/satchel/actionCreator';
+
+describe('simpleSubscribers', () => {
+  let actionCreatorSpy: jasmine.Spy;
+  let decoratorSpy: jasmine.Spy;
+  let simpleSubscriber: Function;
+
+  beforeEach(() => {
+    __resetGlobalContext();
+    actionCreatorSpy = spyOn(actionCreator, 'action').and.callThrough();
+    decoratorSpy = jasmine.createSpy('decoratorSpy');
+    simpleSubscriber = createSimpleSubscriber(decoratorSpy);
+  });
+
+  it('creates and returns a bound action creator', () => {
+    // Arrange
+    let actionId = 'testSubscriber';
+
+    // Act
+    let returnValue = simpleSubscriber(actionId, () => ({}));
+
+    // Assert
+    expect(actionCreatorSpy).toHaveBeenCalled();
+    expect(actionCreatorSpy.calls.argsFor(0)[0]).toBe(actionId);
+    expect(returnValue).toBe(actionCreatorSpy.calls.first().returnValue);
+  });
+
+  it('includes arguments in the action message', () => {
+    // Act
+    let returnValue: Function = simpleSubscriber('testSubscriber', () => ({}));
+    let createdAction = returnValue(1, 2, 3);
+
+    // Assert
+    expect(Array.from(createdAction.args)).toEqual([1, 2, 3]);
+  });
+
+  it('subscribes a callback to the action', () => {
+    // Act
+    simpleSubscriber('testSubscriber', () => ({}));
+
+    // Assert
+    expect(decoratorSpy).toHaveBeenCalled();
+    expect(decoratorSpy.calls.argsFor(0)[0]).toBe(actionCreatorSpy.calls.first().returnValue);
+  });
+
+  it('passes arguments to the callback', () => {
+    // Arrange
+    let callback = jasmine.createSpy('callback');
+    let actionMessage = { args: [1, 2, 3] };
+
+    // Act
+    simpleSubscriber('testSubscriber', callback);
+    let decoratorCallback = decoratorSpy.calls.argsFor(0)[1];
+    decoratorCallback(actionMessage);
+
+    // Assert
+    expect(callback).toHaveBeenCalledWith(1, 2, 3);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,6 +1155,10 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
+exit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -1544,7 +1548,7 @@ glob@7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -2060,6 +2064,18 @@ istanbul-reports@^1.1.3:
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.3.tgz#3b9e1e8defb6d18b1d425da8e8b32c5a163f2d10"
   dependencies:
     handlebars "^4.0.3"
+
+jasmine-core@~2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.8.0.tgz#bcc979ae1f9fd05701e45e52e65d3a5d63f1a24e"
+
+jasmine@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-2.8.0.tgz#6b089c0a11576b1f16df11b80146d91d4e8b8a3e"
+  dependencies:
+    exit "^0.1.2"
+    glob "^7.0.6"
+    jasmine-core "~2.8.0"
 
 jest-changed-files@^21.2.0:
   version "21.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3701,10 +3701,6 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.1.1"
 
-satcheljs@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/satcheljs/-/satcheljs-3.1.0.tgz#e829e92f57e6c3f0090ebffd04e60e2f54ac656a"
-
 sax@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"


### PR DESCRIPTION
We introduce Satcheljs to be part of Poa framework since we need to implement features like:
- [x] await on actions
- [x] throw errors from actions

but those features conflict with Satcheljs ideology.

Also benefit from transfer is reduced bundle, since we remove all legacy code